### PR TITLE
fix typo

### DIFF
--- a/content/_includes/doc/keyboard
+++ b/content/_includes/doc/keyboard
@@ -9,7 +9,7 @@ __Example:__
 {% highlight python %}
 # Wait for a 'z' or 'x' key with a timeout of 3000 ms
 my_keyboard = keyboard(keylist=['z', 'x'], timeout=3000)
-start_time = time()
+start_time = clock.time()
 key, end_time = my_keyboard.get_key()
 var.response = key
 var.response_time = end_time - start_time


### PR DESCRIPTION
In the documentation of the keyboard class, there is a piece of example code, which throws an error. 
Changing `time()` to `clock.time()` solves it. 
