### PR TITLE
Ubuntu install: expyriment

### DIFF
--- a/content/pages/download.md
+++ b/content/pages/download.md
@@ -78,6 +78,7 @@ OpenSesame is available through the [Cogsci.nl PPA](https://launchpad.net/~smath
 sudo add-apt-repository ppa:smathot/cogscinl
 sudo apt-get update
 sudo apt-get install opensesame
+pip install expyriment 
 ~~~
 
 If you experience missing icons, install `gnome-icon-theme-full`.


### PR DESCRIPTION
The default backend is expyriment, yet the Ubuntu PPA does not result in expyriment being installed. This change fixes this as an instruction change. I guess you might prefer to fix it by altering the PPA?