### PR TITLE
Adding parentheses to `print` in parallel.md

### DIFF
--- a/content/pages/manual/devices/parallel.md
+++ b/content/pages/manual/devices/parallel.md
@@ -40,7 +40,7 @@ try:
 	global io
 	io = windll.dlportio # requires dlportio.dll !!!
 except:
-	print 'The parallel port couldn\'t be opened'
+	print('The parallel port couldn\'t be opened')
 ~~~
 
 This will load `dlportio.dll` as a global object called `io`. Please note that failure will not crash the experiment, so make sure to check the debug window for error messages!
@@ -54,7 +54,7 @@ port = 0x378
 try:
 	io.DlPortWritePortUchar(port, trigger)
 except:
-	print 'Failed to send trigger!'
+	print('Failed to send trigger!')
 ~~~
 
 Note that this sends trigger 1 to port 0x378 (=888). Change these values according to your set-up.


### PR DESCRIPTION
Hello, 

I would like to suggest adding parentheses to `print` as pyflakes throws me an error otherwise.

---

In case it's relevant, I provide my session info below.

### System

```
System: Windows-10-10.0.22621-SP0
Architecture: win64
```

### Modules and packages

```
OpenSesame 3.3.14
Python 3.7.6 | packaged by conda-forge | (default, Jan 7 2020, 21:48:41) [MSC v.1916 64 bit (AMD64)]
datamatrix 0.15.3
qdatamatrix 0.1.31
pseudorandom 0.2.2
fileinspector 1.0.2
QNotifications 2.0.6
QOpenScienceFramework 1.3.1
opencv 4.2.0
expyriment 0.10.0+opensesame2
IPython 7.12.0
numpy 1.18.1
scipy 1.3.1
PIL/ PILLOW [version unknown]
psychopy 2022.1.4
pygame 1.9.6
pygaze 0.7.5a5
pyglet 1.5.0
PyQt 5.12.3
serial 3.4
markdown 3.2.1
yaml 5.3
```